### PR TITLE
Update Extract_files_from_Moodle_Course_Backup.ps1

### DIFF
--- a/Extract_files_from_Moodle_Course_Backup.ps1
+++ b/Extract_files_from_Moodle_Course_Backup.ps1
@@ -1,9 +1,34 @@
+#Have yourself an *.mbz file somewhere browse-able and let fly. You'll see a couple of messages you have to acknowledge and a 
+#couple of Windows dialogs to choose a destination folder and file. This update takes advantage of some new(er) tools in later versions of 
+#Powershell and the addition of the "tar" command to Windows to streamline the process with more recent versions of Moodle.
+
+ 
+#Prompt to create or choose destination folder
+Add-Type -AssemblyName PresentationCore,PresentationFramework
+
+[System.Windows.MessageBox]::Show('Choose or create a folder as a destination for the extracted Moodle files.')
+
+
+
+Add-Type -AssemblyName System.Windows.Forms
+
+$FolderBrowser = New-Object System.Windows.Forms.FolderBrowserDialog -Property @{
+    SelectedPath = 'c:\'
+    ShowNewFolderButton = $true
+}
+
+[void]$FolderBrowser.ShowDialog()
+$FolderBrowser.SelectedPath
+
+$MyExtractFolder = $FolderBrowser.SelectedPath
+
+
 # PowerShell script to extract the files from a Moodle course backup
 # PF 2020-09-21
 
 # Moodle changes the filenames of all uploaded files to strings of hex
 # We can look at the database to work out what the original filename is, however
-# the export course package (which is just a .zip) contains an XML file ('files.xml') which we can use as a database
+# the export course package (which is just a tar.gz) contains an XML file ('files.xml') which we can use as a database
 # to convert the files back to their original name.
 
 # Note the files are unchanged, just the filename is encoded.  It would have perhaps been rather obvious
@@ -11,9 +36,53 @@
 
 # Note we need to flip / into \ for Windows.
 
-# UNZIP the backup (just rename it to add .zip) and feed the directory to this variable
 
-$MoodleBackupDir = "C:\Extracted-moodle-course-backup"
+#prompt to choose the mbz file
+
+[System.Windows.MessageBox]::Show('Now choose the *.mbz file you would like to extract. Sit tight. Extracting takes a while.')
+
+Add-Type -AssemblyName System.Windows.Forms
+$FileBrowser = New-Object System.Windows.Forms.OpenFileDialog -Property @{
+    Multiselect = $false # Multiple files can be chosen
+	Filter = 'Moodle Backups (*.mbz)|*.mbz' # Specified file types
+}
+ 
+[void]$FileBrowser.ShowDialog()
+
+$file = $FileBrowser.FileName;
+
+If($FileBrowser.FileNames -like "*\*") {
+
+	# Unzip the tar.gz file and rename 
+	$FileBrowser.FileName #Lists selected files (optional)
+    Copy-Item -Path $FileBrowser.FileName -Destination $FileBrowser.FileName.Replace(".mbz",".tar.gz")
+    $infile = $FileBrowser.FileName.Replace(".mbz",".tar.gz")
+    $outfile = ($infile -replace'\.gz$','')
+    $input = New-Object System.IO.FileStream $infile, ([IO.FileMode]::Open), ([IO.FileAccess]::Read), ([IO.FileShare]::Read)
+    $output = New-Object System.IO.FileStream $outFile, ([IO.FileMode]::Create), ([IO.FileAccess]::Write), ([IO.FileShare]::None)
+    $gzipStream = New-Object System.IO.Compression.GzipStream $input, ([IO.Compression.CompressionMode]::Decompress)
+        $buffer = New-Object byte[](1024)
+    while($true){
+        $read = $gzipstream.Read($buffer, 0, 1024)
+        if ($read -le 0){break}
+        $output.Write($buffer, 0, $read)
+        }
+
+    $gzipStream.Close()
+    $output.Close()
+    $input.Close()
+    tar -xkf $outfile -C $MyExtractFolder
+   
+
+
+	
+}
+
+else {
+    Write-Host "Cancelled by user"
+}
+
+$MoodleBackupDir = $MyExtractFolder
 
 $xml = [xml](Get-Content "$MoodleBackupDir\files.xml")
 
@@ -43,4 +112,6 @@ $xml.SelectNodes("files/file") | Where-Object -Property component -eq "mod_folde
         write-host "!!! Source file $sourcefile DOES NOT EXIST."
     }
 
+
 }
+[System.Windows.MessageBox]::Show('All done! Go check ' + $MyExtractFolder + '\export')


### PR DESCRIPTION
Added folder and file browser options, include unzipping and extracting the tar.gz file. Should now work with only the "mbz" file from Moodle as a starting point.